### PR TITLE
Support fetching logs for `RayJob`s

### DIFF
--- a/backend/src/jobs_server/routers/jobs.py
+++ b/backend/src/jobs_server/routers/jobs.py
@@ -74,6 +74,11 @@ async def logs(
             log_stream = k8s.stream_pod_logs(workload.pod, tail=tail)
             return StreamingResponse(log_stream, media_type="text/plain")
         else:
+            if workload.pod is None:
+                raise HTTPException(
+                    http_status.HTTP_404_NOT_FOUND,
+                    "workload pod not found",
+                )
             return k8s.get_pod_logs(workload.pod, tail=tail)
     except PodNotReadyError as e:
         raise HTTPException(http_status.HTTP_400_BAD_REQUEST, "pod not ready") from e

--- a/backend/src/jobs_server/runner/ray.py
+++ b/backend/src/jobs_server/runner/ray.py
@@ -132,6 +132,10 @@ class RayJobRunner(Runner, KubernetesNamespaceMixin):
 
         suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
         job_id = f"{job.name}-{suffix}"
+
+        # FIXME: Image pull policy should be configurable
+        # It is currently hardcoded to "IfNotPresent" to support running
+        # the E2E tests in a cluster without a proper image registry.
         manifest = {
             "apiVersion": "ray.io/v1",
             "kind": "RayJob",
@@ -158,7 +162,7 @@ class RayJobRunner(Runner, KubernetesNamespaceMixin):
                                     {
                                         "name": "head",
                                         "image": image.tag,
-                                        "imagePullPolicy": "Always",
+                                        "imagePullPolicy": "IfNotPresent",
                                         "resources": {
                                             "requests": res_opts.to_kubernetes(
                                                 kind=K8sResourceKind.REQUESTS
@@ -171,6 +175,18 @@ class RayJobRunner(Runner, KubernetesNamespaceMixin):
                                 ]
                             }
                         },
+                    },
+                },
+                "submitterPodTemplate": {
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "containers": [
+                            {
+                                "name": "ray-submit",
+                                "image": image.tag,
+                                "imagePullPolicy": "IfNotPresent",
+                            }
+                        ],
                     },
                 },
             },

--- a/backend/tests/e2e/clusters.py
+++ b/backend/tests/e2e/clusters.py
@@ -40,6 +40,12 @@ class KubernetesCluster(ABC):
             check=check,
         )
 
+    def helm(self, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["helm", "--kube-context", self.context, *args],
+            check=check,
+        )
+
 
 class KindCluster(KubernetesCluster):
     def create(self):

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -72,8 +72,8 @@ def cluster() -> Generator[KubernetesCluster, None, None]:
         cluster = KindCluster(name=context)
 
     try:
-        setup_kueue(cluster)
         setup_kuberay(cluster)
+        setup_kueue(cluster)
         yield cluster
     finally:
         cluster.delete()

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -72,6 +72,8 @@ def cluster() -> Generator[KubernetesCluster, None, None]:
         cluster = KindCluster(name=context)
 
     try:
+        # Install Kuberay first, so that the CRDs (RayJob, RayCluster)
+        # are available for Kueue to be watched.
         setup_kuberay(cluster)
         setup_kueue(cluster)
         yield cluster

--- a/backend/tests/e2e/resources/job-image/Dockerfile
+++ b/backend/tests/e2e/resources/job-image/Dockerfile
@@ -1,2 +1,6 @@
-FROM alpine:latest
+FROM debian:bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 COPY jobs_execute /usr/local/bin/jobs_execute
+COPY ray /usr/local/bin/ray

--- a/backend/tests/e2e/resources/job-image/ray
+++ b/backend/tests/e2e/resources/job-image/ray
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script serves as a placeholder for the Ray server and submission script.
+# It is used to be able to submit Ray jobs to a test cluster, without having to
+# run a full Ray cluster (or install the Python dependencies in the image).
+
+# IT DOES NOT ACTUALLY PERFORM ANY COMPUTATION.
+
+# Kill the entire process group if the script is terminated
+trap 'kill -TERM -$$' SIGINT SIGTERM
+
+# If `start` is passed, block for 3600 seconds
+if [ "$1" = "start" ]; then
+    echo "Ray server stub"
+
+    # Warning: this is a hack to make all health checks on the head node pod pass.
+    # This is necessary for the Kuberay operator to consider the pod healthy and
+    # proceed with the Ray job submission.
+
+    # Answer 'success' to any HTTP health check on port 52365
+    RESPONSE="success" PORT=52365 perl -MIO::Socket::INET -e '$r=$ENV{RESPONSE};$s=IO::Socket::INET->new(LocalPort=>$ENV{PORT},Listen=>10,Reuse=>1) or die "Cannot create socket: $!\n";while($c=$s->accept()){$c->print("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ".length($r)."\r\nConnection: close\r\n\r\n$r");$c->shutdown(2)}'&
+
+    # Same for port 8265
+    RESPONSE="success" PORT=8265 perl -MIO::Socket::INET -e '$r=$ENV{RESPONSE};$s=IO::Socket::INET->new(LocalPort=>$ENV{PORT},Listen=>10,Reuse=>1) or die "Cannot create socket: $!\n";while($c=$s->accept()){$c->print("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ".length($r)."\r\nConnection: close\r\n\r\n$r");$c->shutdown(2)}'&
+
+    # Pretend to be a Ray server
+    sleep 3600
+else
+    # Any other command immediately succeeds
+    echo "ray $*"
+fi

--- a/backend/tests/e2e/resources/job-image/ray
+++ b/backend/tests/e2e/resources/job-image/ray
@@ -26,6 +26,7 @@ if [ "$1" = "start" ]; then
     # Pretend to be a Ray server
     sleep 3600
 else
-    # Any other command immediately succeeds
+    # Any other command succeeds after a short delay
     echo "ray $*"
+    sleep 2
 fi

--- a/backend/tests/e2e/test_jobs.py
+++ b/backend/tests/e2e/test_jobs.py
@@ -17,7 +17,7 @@ from jobs_server.models import (
 pytestmark = pytest.mark.e2e
 
 
-WORKLOAD_SETTLE_TIME = 30
+WORKLOAD_SETTLE_TIME = 10
 
 
 @pytest.mark.parametrize(
@@ -45,6 +45,8 @@ def test_job_lifecycle(
             resources=ResourceOptions(cpu="1", memory="512Mi"),
         ),
     )
+
+    # Submit a job for execution
     response = client.post("/jobs", json=jsonable_encoder(body))
     managed_resource_id = WorkloadIdentifier.model_validate_json(response.text)
 
@@ -85,3 +87,7 @@ def test_job_lifecycle(
     # Terminate the workload
     response = client.post(f"/jobs/{managed_resource_id.uid}/stop")
     assert response.status_code == 200
+
+    # Check that the workload is not running anymore
+    response = client.post(f"/jobs/{managed_resource_id.uid}/stop")
+    assert response.status_code == 404

--- a/backend/tests/e2e/test_jobs.py
+++ b/backend/tests/e2e/test_jobs.py
@@ -45,7 +45,9 @@ def test_job_lifecycle(
     response = client.post("/jobs", json=jsonable_encoder(body))
     managed_resource_id = WorkloadIdentifier.model_validate_json(response.text)
 
-    time.sleep(0.5)
+    # Give the cluster some time to settle
+    timeout = 0.5 if mode == ExecutionMode.KUEUE else 5
+    time.sleep(timeout)
 
     # Check workload status
     while True:

--- a/backend/tests/e2e/test_jobs.py
+++ b/backend/tests/e2e/test_jobs.py
@@ -88,6 +88,8 @@ def test_job_lifecycle(
     response = client.post(f"/jobs/{managed_resource_id.uid}/stop")
     assert response.status_code == 200
 
+    time.sleep(1)  # Allow some time for the workload to be terminated
+
     # Check that the workload is not running anymore
     response = client.post(f"/jobs/{managed_resource_id.uid}/stop")
     assert response.status_code == 404


### PR DESCRIPTION
Our previous implementation could not fetch the logs for `RayJob` workloads.

This PR adds support and an E2E test case to cover Ray jobs.

## Ray stub in E2E job image

The E2E job image contains a very hacky script `/usr/local/bin/ray`, that can pretend to act as a Ray server.

It includes two Perl one-liners that serve to satisfy the health checks on the worker node pods created by the Kuberay operator, so the actual submission jobs gets created.

It does not perform any computation.