### PR TITLE
Remove --namespace flag from all CLI commands

### DIFF
--- a/client/src/cli/commands/logs.py
+++ b/client/src/cli/commands/logs.py
@@ -8,7 +8,6 @@ from .util import with_job_mgmt_api
 
 
 class LogCommands(Enum):
-    NAMESPACE = "namespace"
     UID = "uid"
     TAIL = "tail"
     FOLLOW = "follow"
@@ -73,11 +72,10 @@ def handle_logs_cmd(args: argparse.Namespace) -> None:
 
 def add_parser(subparsers: Any, parent: argparse.ArgumentParser) -> None:
     # jobby logs, command to fetch logs for workload
-    parser = subparsers.add_parser("logs", description="Get logs for specified job.")
-    parser.add_argument(
-        *LogCommands.NAMESPACE.to_argparse(),
-        help="Kubernetes namespace the job was created in, "
-        "defaults to currently active namespace.",
+    parser = subparsers.add_parser(
+        "logs",
+        parents=[parent],
+        description="Get logs for specified job.",
     )
     parser.add_argument(LogCommands.UID.value, metavar="<ID>")
     parser.add_argument(

--- a/client/src/cli/commands/status.py
+++ b/client/src/cli/commands/status.py
@@ -4,17 +4,13 @@ from pprint import pp
 from typing import Any
 
 import openapi_client
-import openapi_client.configuration
 
 from .util import with_job_mgmt_api
 
 
 @with_job_mgmt_api
 def status(client: openapi_client.JobManagementApi, args: argparse.Namespace) -> None:
-    resp = client.status_jobs_uid_status_get(
-        uid=args.uid,
-        namespace=args.namespace,
-    )
+    resp = client.status_jobs_uid_status_get(uid=args.uid)
     pp(resp)
 
 
@@ -28,10 +24,5 @@ def add_parser(subparsers: Any, parent: ArgumentParser) -> None:
 
     # unique identifier of the job
     parser.add_argument("uid", metavar="<ID>")
-    parser.add_argument(
-        "--namespace",
-        help="Kubernetes namespace the job was created in, "
-        "defaults to currently active namespace.",
-    )
     # TODO: Factor out into command class
     parser.set_defaults(func=status)

--- a/client/src/cli/commands/stop.py
+++ b/client/src/cli/commands/stop.py
@@ -9,9 +9,7 @@ from .util import with_job_mgmt_api
 
 @with_job_mgmt_api
 def stop(client: openapi_client.JobManagementApi, args: argparse.Namespace) -> None:
-    resp = client.stop_workload_jobs_uid_stop_post(
-        uid=args.uid, namespace=args.namespace
-    )
+    resp = client.stop_workload_jobs_uid_stop_post(uid=args.uid)
     pp(resp)
 
 
@@ -21,11 +19,6 @@ def add_parser(subparsers: Any, parent: argparse.ArgumentParser) -> None:
         "stop",
         parents=[parent],
         description="Terminate the execution of a previously dispatched job.",
-    )
-    parser.add_argument(
-        "--namespace",
-        help="Kubernetes namespace the job was created in, "
-        "defaults to currently active namespace.",
     )
     parser.add_argument("uid", metavar="<ID>")
     parser.set_defaults(func=stop)

--- a/client/src/cli/commands/submit.py
+++ b/client/src/cli/commands/submit.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 import os
@@ -8,7 +6,6 @@ from pprint import pp
 from typing import Any
 
 import openapi_client
-import openapi_client.configuration
 from jobs import Image, Job
 from jobs.submission_context import SubmissionContext
 from openapi_client import ExecutionMode
@@ -131,11 +128,6 @@ def add_parser(subparsers: Any, parent: argparse.ArgumentParser) -> None:
         "--ray-head-url",
         help="URL of the Ray cluster head node",
         default="http://localhost:8265",
-    )
-
-    parser.add_argument(
-        "--namespace",
-        help="Kubernetes namespace to create resources in, defaults to currently active namespace",
     )
 
     parser.add_argument("entrypoint")


### PR DESCRIPTION
The namespace is a configuration detail on the k8s cluster, and is not necessarily available and configurable for the user. Also, since we are working with UIDs on the client side, we can reference jobs and workloads reliably across namespaces (iff they are visible to the user).

---------------------------------

I'm not sure if we might want to keep it on `jobby submit`. Do we rely on the ~fact~ assumption that the Kueue is set up in the currently active namespace on the cluster, or do we teach the backend to grab the namespace associated with the submitter?