### PR TITLE
Add API endpoint to list workloads

### DIFF
--- a/backend/src/jobs_server/__main__.py
+++ b/backend/src/jobs_server/__main__.py
@@ -20,7 +20,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-app.include_router(jobs.router)
+app.include_router(jobs.router, prefix="/jobs")
 
 
 @app.get("/health", include_in_schema=False)

--- a/backend/src/jobs_server/services/k8s.py
+++ b/backend/src/jobs_server/services/k8s.py
@@ -113,3 +113,16 @@ class KubernetesService:
             namespace=namespace,
             body=client.V1DeleteOptions(propagation_policy=propagation_policy),
         )
+
+    def list_workloads(self, namespace: str | None = None) -> list[KueueWorkload]:
+        api = client.CustomObjectsApi()
+        workloads = api.list_namespaced_custom_object(
+            group="kueue.x-k8s.io",
+            version="v1beta1",
+            namespace=namespace or self.namespace,
+            plural="workloads",
+        )
+        return [
+            KueueWorkload.model_validate(workload)
+            for workload in workloads.get("items", [])
+        ]


### PR DESCRIPTION
## `GET /jobs` endpoint

The `GET /jobs` endpoint can either return workload identifiers, or optionally the workload metadata:

![image](https://github.com/user-attachments/assets/81c3025a-7d52-4bbe-9358-2260562338ce)

## Misc changes

Additionally, the path prefix has been removed from the endpoints in the `jobs` router, instead it is now mounted with an appropriate path prefix.