### PR TITLE
Enable multi-pod log collection in both ex-post and streaming modes

### DIFF
--- a/backend/src/jobs_server/runner/kueue.py
+++ b/backend/src/jobs_server/runner/kueue.py
@@ -41,7 +41,7 @@ class KueueRunner(Runner):
         container = client.V1Container(
             image=image.tag,
             image_pull_policy="IfNotPresent",
-            name="dummy-job",
+            name="workload",
             command=_make_executor_command(job),
             resources=(
                 {
@@ -64,8 +64,8 @@ class KueueRunner(Runner):
             kind="Job",
             metadata=metadata,
             spec=client.V1JobSpec(
-                parallelism=1,
-                completions=1,
+                parallelism=3,
+                # completions=1,
                 suspend=True,
                 template=template,
             ),

--- a/backend/tests/integration/test_jobs.py
+++ b/backend/tests/integration/test_jobs.py
@@ -167,6 +167,17 @@ class TestJobStatus:
 
 
 class TestJobLogs:
+    class MyWorkload:
+        """
+        Non-functional dummy workload that just needs to pass
+        the logs endpoint's pod number checks.
+        """
+
+        @property
+        def pods(self):
+            # we only check len(workload.pods) > 0, so this should do.
+            return ["hello"]
+
     def test_not_found(self, client: TestClient, mocker: MockFixture) -> None:
         mock = mocker.patch.object(
             KubernetesService,
@@ -190,6 +201,7 @@ class TestJobLogs:
         mock = mocker.patch.object(
             KubernetesService,
             "workload_for_managed_resource",
+            return_value=self.MyWorkload(),
         )
 
         # Mock the appropriate pod logs function to raise an error
@@ -211,6 +223,7 @@ class TestJobLogs:
         mock = mocker.patch.object(
             KubernetesService,
             "workload_for_managed_resource",
+            return_value=self.MyWorkload(),
         )
         mock_pod_logs = mocker.patch.object(
             KubernetesService,
@@ -232,6 +245,7 @@ class TestJobLogs:
         mock = mocker.patch.object(
             KubernetesService,
             "workload_for_managed_resource",
+            return_value=self.MyWorkload(),
         )
         mock_pod_logs = mocker.patch.object(
             KubernetesService,


### PR DESCRIPTION
The streaming case is really difficult, since the previous "stream" is a (synchronous) generator around an urllib response body.

In the multi-pod case, we just stream these responses (from the k8s API) line-by-line. It seems that because of this synchronicity, in the worst case, we wait for the slowest pod to log again, which can potentially stall log output from all pods indefinitely. It is unclear how to resolve this without going to a fully asynchronous approach.

In the static case, we simply fetch all logs and concatenate them into a big string.

Closes #85.